### PR TITLE
Google Image Charts is (sadly) deprecated

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ def robots():
 def get_chart_image(collection, view):
 	d, p, t, _ = get_stats(collection, view)
 
-	return redirect(f"https://chart.googleapis.com/chart?cht=p&chd=t:{d},{p},{t}&chs={image_size}&chdl={'|'.join(labels)}")
+	return redirect(f"https://image-charts.com/chart?cht=p&chd=t:{d},{p},{t}&chs={image_size}&chdl={'|'.join(labels)}")
 
 
 @app.route('/chart/<collection>/<view>')


### PR DESCRIPTION
Hello!

Google Image Charts is deprecated and the "servers are running on fumes":

> The service is running on fumes: as soon as the current serving jobs go 
> down, they are unlikely to come back up. I would migrate off immediately.

[Source](https://groups.google.com/forum/#!original/google-chart-api/rZtHTyYgyXI/z67NKmx7DAAJ)

We've built an alternative back in 2016 (called [Image-Charts API](https://www.image-charts.com)) and it's now a stable, viable company that let us run a drop-in replacement and compatible API for *free*!

Enjoy!